### PR TITLE
use AWS_REGION in boto3 client

### DIFF
--- a/handler.py
+++ b/handler.py
@@ -8,7 +8,9 @@ from dateutil.parser import parse
 
 print("Loading function")
 
-s3 = boto3.client("s3")
+region = os.getenv("AWS_REGION") # add automatically by lambda
+
+s3 = boto3.client("s3", region_name=region)
 fields_prefix = "#Fields: "
 
 

--- a/handler.py
+++ b/handler.py
@@ -8,7 +8,7 @@ from dateutil.parser import parse
 
 print("Loading function")
 
-region = os.getenv("AWS_REGION") # add automatically by lambda
+region = os.getenv("AWS_REGION")  # add automatically by lambda
 
 s3 = boto3.client("s3", region_name=region)
 fields_prefix = "#Fields: "


### PR DESCRIPTION
AWS_REGION is added automatically by lambda, I have added it to the arguments on initiating an instance from boto3 s3 client