### PR TITLE
feat: add support for edge ingestion

### DIFF
--- a/axiom-cloudfront-lambda-base-cloudformation-stack.template.yaml
+++ b/axiom-cloudfront-lambda-base-cloudformation-stack.template.yaml
@@ -12,11 +12,11 @@ Parameters:
   AxiomURL:
     Type: String
     Default: ""
-    Description: URI of the Axiom endpoint. If a path is provided, used as-is. If no path, /v1/datasets/{dataset}/ingest is appended. Takes precedence over AxiomRegion.
-  AxiomRegion:
+    Description: URI of the Axiom endpoint. If a path is provided, used as-is. If no path, /v1/datasets/{dataset}/ingest is appended. Takes precedence over AxiomEdgeURL.
+  AxiomEdgeURL:
     Type: String
     Default: ""
-    Description: Axiom regional edge domain (e.g., eu-central-1.aws.edge.axiom.co). Domain only, no scheme/path. Data sent to https://{region}/v1/ingest/{dataset}.
+    Description: Axiom regional edge domain (e.g., eu-central-1.aws.edge.axiom.co). Domain only, no scheme/path. Data sent to https://{edge_url}/v1/ingest/{dataset}.
   AxiomDataset:
     Type: String
     Description: The Name of the Dataset in Axiom.
@@ -70,7 +70,7 @@ Resources:
           AXIOM_TOKEN: !Ref 'AxiomToken'
           AXIOM_DATASET: !Ref 'AxiomDataset'
           AXIOM_URL: !Ref 'AxiomURL'
-          AXIOM_REGION: !Ref 'AxiomRegion'
+          AXIOM_EDGE_URL: !Ref 'AxiomEdgeURL'
   LogsLambdaPermission:
     Type: AWS::Lambda::Permission
     DependsOn:

--- a/axiom-cloudfront-lambda-base-cloudformation-stack.template.yaml
+++ b/axiom-cloudfront-lambda-base-cloudformation-stack.template.yaml
@@ -12,8 +12,8 @@ Parameters:
   AxiomURL:
     Type: String
     Default: ""
-    Description: The base URL of Axiom API endpoint (legacy). Use AxiomIngestURL for edge deployments.
-  AxiomIngestURL:
+    Description: The base URL of Axiom API endpoint (legacy). Use AxiomEdgeURL for edge deployments.
+  AxiomEdgeURL:
     Type: String
     Default: ""
     Description: The Axiom edge ingest endpoint URL (e.g., https://eu-central-1.aws.edge.axiom.co). Takes precedence over AxiomURL.
@@ -70,7 +70,7 @@ Resources:
           AXIOM_TOKEN: !Ref 'AxiomToken'
           AXIOM_DATASET: !Ref 'AxiomDataset'
           AXIOM_URL: !Ref 'AxiomURL'
-          AXIOM_INGEST_URL: !Ref 'AxiomIngestURL'
+          AXIOM_EDGE_URL: !Ref 'AxiomEdgeURL'
   LogsLambdaPermission:
     Type: AWS::Lambda::Permission
     DependsOn:

--- a/axiom-cloudfront-lambda-base-cloudformation-stack.template.yaml
+++ b/axiom-cloudfront-lambda-base-cloudformation-stack.template.yaml
@@ -11,8 +11,12 @@ Parameters:
     AllowedPattern: "^(xaat-|xait-).*"
   AxiomURL:
     Type: String
-    Default: "https://cloud.axiom.co"
-    Description: The URL of Axiom endpoint. Defaults to "https://cloud.axiom.co".
+    Default: ""
+    Description: The base URL of Axiom API endpoint (legacy). Use AxiomIngestURL for edge deployments.
+  AxiomIngestURL:
+    Type: String
+    Default: ""
+    Description: The Axiom edge ingest endpoint URL (e.g., https://eu-central-1.aws.edge.axiom.co). Takes precedence over AxiomURL.
   AxiomDataset:
     Type: String
     Description: The Name of the Dataset in Axiom.
@@ -66,6 +70,7 @@ Resources:
           AXIOM_TOKEN: !Ref 'AxiomToken'
           AXIOM_DATASET: !Ref 'AxiomDataset'
           AXIOM_URL: !Ref 'AxiomURL'
+          AXIOM_INGEST_URL: !Ref 'AxiomIngestURL'
   LogsLambdaPermission:
     Type: AWS::Lambda::Permission
     DependsOn:

--- a/axiom-cloudfront-lambda-base-cloudformation-stack.template.yaml
+++ b/axiom-cloudfront-lambda-base-cloudformation-stack.template.yaml
@@ -12,11 +12,11 @@ Parameters:
   AxiomURL:
     Type: String
     Default: ""
-    Description: URI of the Axiom endpoint. If a path is provided, used as-is. If no path, /v1/datasets/{dataset}/ingest is appended. Takes precedence over AxiomEdgeURL.
+    Description: Base Axiom API URL (legacy). If a path is provided, used as-is. If no path, /v1/datasets/{dataset}/ingest is appended.
   AxiomEdgeURL:
     Type: String
     Default: ""
-    Description: Axiom regional edge domain (e.g., eu-central-1.aws.edge.axiom.co). Domain only, no scheme/path. Data sent to https://{edge_url}/v1/ingest/{dataset}.
+    Description: Edge endpoint URL for regional ingestion (e.g., https://eu-central-1.aws.edge.axiom.co). Takes precedence over AxiomURL. If no path, /v1/ingest/{dataset} is appended.
   AxiomDataset:
     Type: String
     Description: The Name of the Dataset in Axiom.

--- a/axiom-cloudfront-lambda-base-cloudformation-stack.template.yaml
+++ b/axiom-cloudfront-lambda-base-cloudformation-stack.template.yaml
@@ -12,11 +12,11 @@ Parameters:
   AxiomURL:
     Type: String
     Default: ""
-    Description: The base URL of Axiom API endpoint (legacy). Use AxiomEdgeURL for edge deployments.
-  AxiomEdgeURL:
+    Description: URI of the Axiom endpoint. If a path is provided, used as-is. If no path, /v1/datasets/{dataset}/ingest is appended. Takes precedence over AxiomRegion.
+  AxiomRegion:
     Type: String
     Default: ""
-    Description: The Axiom edge ingest endpoint URL (e.g., https://eu-central-1.aws.edge.axiom.co). Takes precedence over AxiomURL.
+    Description: Axiom regional edge domain (e.g., eu-central-1.aws.edge.axiom.co). Domain only, no scheme/path. Data sent to https://{region}/v1/ingest/{dataset}.
   AxiomDataset:
     Type: String
     Description: The Name of the Dataset in Axiom.
@@ -70,7 +70,7 @@ Resources:
           AXIOM_TOKEN: !Ref 'AxiomToken'
           AXIOM_DATASET: !Ref 'AxiomDataset'
           AXIOM_URL: !Ref 'AxiomURL'
-          AXIOM_EDGE_URL: !Ref 'AxiomEdgeURL'
+          AXIOM_REGION: !Ref 'AxiomRegion'
   LogsLambdaPermission:
     Type: AWS::Lambda::Permission
     DependsOn:

--- a/axiom-cloudfront-lambda-cloudformation-stack.template.yaml
+++ b/axiom-cloudfront-lambda-cloudformation-stack.template.yaml
@@ -16,11 +16,11 @@ Parameters:
   AxiomURL:
     Type: String
     Default: ""
-    Description: URI of the Axiom endpoint. If a path is provided, used as-is. If no path, /v1/datasets/{dataset}/ingest is appended. Takes precedence over AxiomRegion.
-  AxiomRegion:
+    Description: URI of the Axiom endpoint. If a path is provided, used as-is. If no path, /v1/datasets/{dataset}/ingest is appended. Takes precedence over AxiomEdgeURL.
+  AxiomEdgeURL:
     Type: String
     Default: ""
-    Description: Axiom regional edge domain (e.g., eu-central-1.aws.edge.axiom.co). Domain only, no scheme/path. Data sent to https://{region}/v1/ingest/{dataset}.
+    Description: Axiom regional edge domain (e.g., eu-central-1.aws.edge.axiom.co). Domain only, no scheme/path. Data sent to https://{edge_url}/v1/ingest/{dataset}.
   AxiomDataset:
     Type: String
     Description: The Name of the Dataset in Axiom.
@@ -93,7 +93,7 @@ Resources:
           AXIOM_TOKEN: !Ref 'AxiomToken'
           AXIOM_DATASET: !Ref 'AxiomDataset'
           AXIOM_URL: !Ref 'AxiomURL'
-          AXIOM_REGION: !Ref 'AxiomRegion'
+          AXIOM_EDGE_URL: !Ref 'AxiomEdgeURL'
   LogsLambdaPermission:
     Type: AWS::Lambda::Permission
     DependsOn:

--- a/axiom-cloudfront-lambda-cloudformation-stack.template.yaml
+++ b/axiom-cloudfront-lambda-cloudformation-stack.template.yaml
@@ -16,11 +16,11 @@ Parameters:
   AxiomURL:
     Type: String
     Default: ""
-    Description: The base URL of Axiom API endpoint (legacy). Use AxiomEdgeURL for edge deployments.
-  AxiomEdgeURL:
+    Description: URI of the Axiom endpoint. If a path is provided, used as-is. If no path, /v1/datasets/{dataset}/ingest is appended. Takes precedence over AxiomRegion.
+  AxiomRegion:
     Type: String
     Default: ""
-    Description: The Axiom edge ingest endpoint URL (e.g., https://eu-central-1.aws.edge.axiom.co). Takes precedence over AxiomURL.
+    Description: Axiom regional edge domain (e.g., eu-central-1.aws.edge.axiom.co). Domain only, no scheme/path. Data sent to https://{region}/v1/ingest/{dataset}.
   AxiomDataset:
     Type: String
     Description: The Name of the Dataset in Axiom.
@@ -93,7 +93,7 @@ Resources:
           AXIOM_TOKEN: !Ref 'AxiomToken'
           AXIOM_DATASET: !Ref 'AxiomDataset'
           AXIOM_URL: !Ref 'AxiomURL'
-          AXIOM_EDGE_URL: !Ref 'AxiomEdgeURL'
+          AXIOM_REGION: !Ref 'AxiomRegion'
   LogsLambdaPermission:
     Type: AWS::Lambda::Permission
     DependsOn:

--- a/axiom-cloudfront-lambda-cloudformation-stack.template.yaml
+++ b/axiom-cloudfront-lambda-cloudformation-stack.template.yaml
@@ -16,11 +16,11 @@ Parameters:
   AxiomURL:
     Type: String
     Default: ""
-    Description: URI of the Axiom endpoint. If a path is provided, used as-is. If no path, /v1/datasets/{dataset}/ingest is appended. Takes precedence over AxiomEdgeURL.
+    Description: Base Axiom API URL (legacy). If a path is provided, used as-is. If no path, /v1/datasets/{dataset}/ingest is appended.
   AxiomEdgeURL:
     Type: String
     Default: ""
-    Description: Axiom regional edge domain (e.g., eu-central-1.aws.edge.axiom.co). Domain only, no scheme/path. Data sent to https://{edge_url}/v1/ingest/{dataset}.
+    Description: Edge endpoint URL for regional ingestion (e.g., https://eu-central-1.aws.edge.axiom.co). Takes precedence over AxiomURL. If no path, /v1/ingest/{dataset} is appended.
   AxiomDataset:
     Type: String
     Description: The Name of the Dataset in Axiom.

--- a/axiom-cloudfront-lambda-cloudformation-stack.template.yaml
+++ b/axiom-cloudfront-lambda-cloudformation-stack.template.yaml
@@ -15,8 +15,12 @@ Parameters:
     AllowedPattern: "^(xaat-|xait-).*"
   AxiomURL:
     Type: String
-    Default: "https://cloud.axiom.co"
-    Description: The URL of Axiom endpoint. Defaults to "https://cloud.axiom.co".
+    Default: ""
+    Description: The base URL of Axiom API endpoint (legacy). Use AxiomIngestURL for edge deployments.
+  AxiomIngestURL:
+    Type: String
+    Default: ""
+    Description: The Axiom edge ingest endpoint URL (e.g., https://eu-central-1.aws.edge.axiom.co). Takes precedence over AxiomURL.
   AxiomDataset:
     Type: String
     Description: The Name of the Dataset in Axiom.
@@ -89,6 +93,7 @@ Resources:
           AXIOM_TOKEN: !Ref 'AxiomToken'
           AXIOM_DATASET: !Ref 'AxiomDataset'
           AXIOM_URL: !Ref 'AxiomURL'
+          AXIOM_INGEST_URL: !Ref 'AxiomIngestURL'
   LogsLambdaPermission:
     Type: AWS::Lambda::Permission
     DependsOn:

--- a/axiom-cloudfront-lambda-cloudformation-stack.template.yaml
+++ b/axiom-cloudfront-lambda-cloudformation-stack.template.yaml
@@ -16,8 +16,8 @@ Parameters:
   AxiomURL:
     Type: String
     Default: ""
-    Description: The base URL of Axiom API endpoint (legacy). Use AxiomIngestURL for edge deployments.
-  AxiomIngestURL:
+    Description: The base URL of Axiom API endpoint (legacy). Use AxiomEdgeURL for edge deployments.
+  AxiomEdgeURL:
     Type: String
     Default: ""
     Description: The Axiom edge ingest endpoint URL (e.g., https://eu-central-1.aws.edge.axiom.co). Takes precedence over AxiomURL.
@@ -93,7 +93,7 @@ Resources:
           AXIOM_TOKEN: !Ref 'AxiomToken'
           AXIOM_DATASET: !Ref 'AxiomDataset'
           AXIOM_URL: !Ref 'AxiomURL'
-          AXIOM_INGEST_URL: !Ref 'AxiomIngestURL'
+          AXIOM_EDGE_URL: !Ref 'AxiomEdgeURL'
   LogsLambdaPermission:
     Type: AWS::Lambda::Permission
     DependsOn:

--- a/handler.py
+++ b/handler.py
@@ -98,14 +98,14 @@ def build_ingest_url(dataset):
     """
     Build the ingest URL based on environment configuration.
 
-    Priority: AXIOM_URL > AXIOM_REGION > default cloud endpoint
+    Priority: AXIOM_URL > AXIOM_EDGE_URL > default cloud endpoint
 
     - AXIOM_URL: URI of the Axiom endpoint to send data to.
                  If a path is provided, the URL is used as-is.
                  If no path (or only `/`) is provided, `/v1/datasets/{dataset}/ingest`
                  is appended for backwards compatibility.
-    - AXIOM_REGION: The Axiom regional edge domain (domain name only, no scheme/path).
-                    When set, data is sent to `https://{region}/v1/ingest/{dataset}`.
+    - AXIOM_EDGE_URL: The Axiom regional edge domain (domain name only, no scheme/path).
+                      When set, data is sent to `https://{edge_url}/v1/ingest/{dataset}`.
     """
     axiom_url = os.getenv("AXIOM_URL")
     if axiom_url:
@@ -116,10 +116,10 @@ def build_ingest_url(dataset):
             return f"{url}/v1/datasets/{dataset}/ingest"
         return url
 
-    axiom_region = os.getenv("AXIOM_REGION")
-    if axiom_region:
-        region = axiom_region.rstrip("/")
-        return f"https://{region}/v1/ingest/{dataset}"
+    axiom_edge_url = os.getenv("AXIOM_EDGE_URL")
+    if axiom_edge_url:
+        edge_url = axiom_edge_url.rstrip("/")
+        return f"https://{edge_url}/v1/ingest/{dataset}"
 
     return f"https://cloud.axiom.co/v1/datasets/{dataset}/ingest"
 

--- a/handler.py
+++ b/handler.py
@@ -44,44 +44,50 @@ def log_to_event(log):
         "user_agent": log["cs(User-Agent)"] if log["cs(User-Agent)"] != "-" else None,
         "query_string": log["cs-uri-query"] if log["cs-uri-query"] != "-" else None,
         "cookie": log["cs(Cookie)"] if log["cs(Cookie)"] != "-" else None,
-        "result_type": log["x-edge-result-type"]
-        if log["x-edge-result-type"] != "-"
-        else None,
-        "request_id": log["x-edge-request-id"]
-        if log["x-edge-request-id"] != "-"
-        else None,
+        "result_type": (
+            log["x-edge-result-type"] if log["x-edge-result-type"] != "-" else None
+        ),
+        "request_id": (
+            log["x-edge-request-id"] if log["x-edge-request-id"] != "-" else None
+        ),
         "host_header": log["x-host-header"] if log["x-host-header"] != "-" else None,
         "request_protocol": log["cs-protocol"] if log["cs-protocol"] != "-" else None,
         "request_bytes": int(log["cs-bytes"]) if log["cs-bytes"] != "-" else None,
         "time_taken_s": float(log["time-taken"]) if log["time-taken"] != "-" else None,
-        "x_forwarded_for": log["x-forwarded-for"]
-        if log["x-forwarded-for"] != "-"
-        else None,
+        "x_forwarded_for": (
+            log["x-forwarded-for"] if log["x-forwarded-for"] != "-" else None
+        ),
         "ssl_protocol": log["ssl-protocol"] if log["ssl-protocol"] != "-" else None,
         "ssl_cipher": log["ssl-cipher"] if log["ssl-cipher"] != "-" else None,
-        "response_result_type": log["x-edge-response-result-type"]
-        if log["x-edge-response-result-type"] != "-"
-        else None,
-        "http_version": log["cs-protocol-version"]
-        if log["cs-protocol-version"] != "-"
-        else None,
+        "response_result_type": (
+            log["x-edge-response-result-type"]
+            if log["x-edge-response-result-type"] != "-"
+            else None
+        ),
+        "http_version": (
+            log["cs-protocol-version"] if log["cs-protocol-version"] != "-" else None
+        ),
         "fle_status": log["fle-status"] if log["fle-status"] != "-" else None,
-        "fle_encrypted_fields": log["fle-encrypted-fields"]
-        if log["fle-encrypted-fields"] != "-"
-        else None,
+        "fle_encrypted_fields": (
+            log["fle-encrypted-fields"] if log["fle-encrypted-fields"] != "-" else None
+        ),
         "port": int(log["c-port"]) if log["c-port"] != "-" else None,
-        "time_to_first_byte_s": float(log["time-to-first-byte"])
-        if log["time-to-first-byte"] != "-"
-        else None,
-        "x_edge_detailed_result_type": log["x-edge-detailed-result-type"]
-        if log["x-edge-detailed-result-type"] != "-"
-        else None,
-        "content_type": log["sc-content-type"]
-        if log["sc-content-type"] != "-"
-        else None,
-        "content_len": int(log["sc-content-len"])
-        if log["sc-content-len"] != "-"
-        else None,
+        "time_to_first_byte_s": (
+            float(log["time-to-first-byte"])
+            if log["time-to-first-byte"] != "-"
+            else None
+        ),
+        "x_edge_detailed_result_type": (
+            log["x-edge-detailed-result-type"]
+            if log["x-edge-detailed-result-type"] != "-"
+            else None
+        ),
+        "content_type": (
+            log["sc-content-type"] if log["sc-content-type"] != "-" else None
+        ),
+        "content_len": (
+            int(log["sc-content-len"]) if log["sc-content-len"] != "-" else None
+        ),
         "range_start": log["sc-range-start"] if log["sc-range-start"] != "-" else None,
         "range_end": log["sc-range-end"] if log["sc-range-end"] != "-" else None,
     }
@@ -91,9 +97,9 @@ def log_to_event(log):
 def build_ingest_url(dataset):
     """
     Build the ingest URL based on environment configuration.
-    
+
     Priority: AXIOM_INGEST_URL > AXIOM_URL > default cloud endpoint
-    
+
     - AXIOM_INGEST_URL: Edge ingest endpoint (e.g., https://eu-central-1.aws.edge.axiom.co)
                         Uses new path format: /v1/ingest/{dataset}
     - AXIOM_URL: Legacy base URL for backwards compatibility

--- a/handler.py
+++ b/handler.py
@@ -98,16 +98,16 @@ def build_ingest_url(dataset):
     """
     Build the ingest URL based on environment configuration.
 
-    Priority: AXIOM_INGEST_URL > AXIOM_URL > default cloud endpoint
+    Priority: AXIOM_EDGE_URL > AXIOM_URL > default cloud endpoint
 
-    - AXIOM_INGEST_URL: Edge ingest endpoint (e.g., https://eu-central-1.aws.edge.axiom.co)
-                        Uses new path format: /v1/ingest/{dataset}
+    - AXIOM_EDGE_URL: Edge ingest endpoint (e.g., https://eu-central-1.aws.edge.axiom.co)
+                      Uses new path format: /v1/ingest/{dataset}
     - AXIOM_URL: Legacy base URL for backwards compatibility
                  Uses legacy path format: /api/v1/datasets/{dataset}/ingest
     """
-    ingest_url = os.getenv("AXIOM_INGEST_URL")
-    if ingest_url:
-        return f"{ingest_url.rstrip('/')}/v1/ingest/{dataset}"
+    edge_url = os.getenv("AXIOM_EDGE_URL")
+    if edge_url:
+        return f"{edge_url.rstrip('/')}/v1/ingest/{dataset}"
 
     axiom_url = os.getenv("AXIOM_URL")
     if axiom_url:


### PR DESCRIPTION
## Summary

Add support for Axiom's regional edge ingestion endpoints, consistent with [axiom-go#401](https://github.com/axiomhq/axiom-go/pull/401) and [Vector#24037](https://github.com/vectordotdev/vector/pull/24037).

## Configuration

### Environment Variables

| Variable | Description |
|----------|-------------|
| `AXIOM_EDGE_URL` | Edge endpoint URL for regional ingestion. Smart path handling: if path provided, used as-is; if no path, `/v1/ingest/{dataset}` is appended. Takes precedence over `AXIOM_URL`. |
| `AXIOM_URL` | Base Axiom API URL (legacy). Smart path handling: if path provided, used as-is; if no path, `/v1/datasets/{dataset}/ingest` is appended. |

**Priority:** `AXIOM_EDGE_URL` > `AXIOM_URL` > default cloud endpoint

### Examples

| Configuration | Value | Generated URL |
|---------------|-------|---------------|
| `AXIOM_EDGE_URL` (no path) | `https://eu-central-1.aws.edge.axiom.co` | `https://eu-central-1.aws.edge.axiom.co/v1/ingest/{dataset}` |
| `AXIOM_EDGE_URL` (with path) | `http://localhost:3400/ingest` | `http://localhost:3400/ingest` |
| `AXIOM_URL` (no path) | `https://api.eu.axiom.co` | `https://api.eu.axiom.co/v1/datasets/{dataset}/ingest` |
| `AXIOM_URL` (with path) | `http://localhost:3400/ingest` | `http://localhost:3400/ingest` |
| Default (nothing set) | - | `https://cloud.axiom.co/v1/datasets/{dataset}/ingest` |

## Backwards Compatibility

Fully backwards compatible — existing configurations work unchanged. Edge routing is opt-in and only used when `AXIOM_EDGE_URL` is explicitly configured.

## References

- [axiom-go PR #401](https://github.com/axiomhq/axiom-go/pull/401)
- [Vector PR #24037](https://github.com/vectordotdev/vector/pull/24037)
- [Axiom Edge Deployments Documentation](https://axiom.co/docs/reference/edge-deployments)